### PR TITLE
Fix AttributeConsumeGameplayEffect incorrect attribute name

### DIFF
--- a/addons/godot-gameplay-attributes/premade_gameplay_effects/AttributeConsumeGameplayEffect.gd
+++ b/addons/godot-gameplay-attributes/premade_gameplay_effects/AttributeConsumeGameplayEffect.gd
@@ -24,6 +24,6 @@ func apply_effect() -> void:
 	
 	if parent:
 		var attribute: GameplayAttribute = parent.get_attribute(attribute_name)
-		if attribute and attribute.attribute_name == attribute_name:
+		if attribute and attribute.name == attribute_name:
 			attribute.current_value = clamp(attribute.current_value - abs(consume_per_second), 0, attribute.max_value)
 			emit_signal("effect_applied", self)

--- a/example/addons/godot-gameplay-attributes/premade_gameplay_effects/AttributeConsumeGameplayEffect.gd
+++ b/example/addons/godot-gameplay-attributes/premade_gameplay_effects/AttributeConsumeGameplayEffect.gd
@@ -24,6 +24,6 @@ func apply_effect() -> void:
 	
 	if parent:
 		var attribute: GameplayAttribute = parent.get_attribute(attribute_name)
-		if attribute and attribute.attribute_name == attribute_name:
+		if attribute and attribute.name == attribute_name:
 			attribute.current_value = clamp(attribute.current_value - abs(consume_per_second), 0, attribute.max_value)
 			emit_signal("effect_applied", self)


### PR DESCRIPTION
AttributeConsumeGameplayEffect attempts to access `.attribute_name` rather than `.name`, causing an 
```
Invalid get index 'attribute_name' (on base: 'Node (GameplayAttribute.gd)').
```
error.